### PR TITLE
ft(view_sessions): add view session api

### DIFF
--- a/server/controllers/session_controller.js
+++ b/server/controllers/session_controller.js
@@ -1,0 +1,30 @@
+import  db from '../models/session_model'
+class Session_controller
+{
+
+getall = (req,res)=>
+{
+if(res.pass_info.user_info.role == "mentor")
+{
+
+    //**** mentor get all session request by different user  ****/ 
+
+const all=db.all_sessions(res.pass_info.user_info.id);
+if(!all){return res.status(204).json({status:204,message:"no request so far..."})}
+return res.status(200).json({status:200,message:"view all request",data:all})
+}
+
+if(res.pass_info.user_info.role == "mentee")
+{
+    // *****this will get all session request made by mentee ***/
+    
+const single_mentor=db.all_session_request(res.pass_info.user_info.id)
+if(!single_mentor){return res.status(404).json({status:404,message:"user does not exist"})}
+return res.status(200).json({status:200,data:single_mentor});
+}
+
+}
+
+}
+
+ export default new Session_controller();

--- a/server/index.js
+++ b/server/index.js
@@ -4,7 +4,9 @@ import authroute from './routes/Auth';
 import adminroute from './routes/admin';
 import menteeroute from './routes/mentee';
 import mentorroute from './routes/mentor';
+import sessionroute from './routes/sessions';
 import not_found from './routes/default';
+
 
 const app = express();
 
@@ -14,6 +16,8 @@ app.use('/api/v1', authroute);
 app.use('/api/v1', adminroute);
 app.use('/api/v1', mentorroute);
 app.use('/api/v1', menteeroute);
+app.use('/api/v1', sessionroute);
+
 
 app.use(not_found);
 

--- a/server/models/session_model.js
+++ b/server/models/session_model.js
@@ -1,0 +1,27 @@
+import user_table from './memory';
+const db=user_table.session;
+class Session_modal 
+{
+
+   // select all session request for specific mentor
+  
+   all_sessions  =(data)=>
+   {
+   const all_sessions= db.filter(specific=> specific.mentorId==data)
+    return all_sessions;
+   }
+   
+   // all session made by single user
+  
+    all_session_request=(data)=>
+   {
+    const all_request=db.filter(all=> all.menteeId==data)
+    return all_request;
+   }
+
+
+  
+
+
+}
+export default new Session_modal();

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import sessions from '../controllers/session_controller';
+import { TOKEN, PASS } from '../middleware/verify';
+
+const router = Router();
+
+
+// optional:either user or mentor can view sessions that correspondes to him
+
+router.get('/sessions', TOKEN, PASS, sessions.getall);
+
+
+// export router
+export default router;

--- a/server/test/all_test.js
+++ b/server/test/all_test.js
@@ -2,6 +2,7 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import jwt from 'jsonwebtoken';
+import default_route from '../routes/default'
 import { config } from 'dotenv';
 import { TOKEN } from '../middleware/verify';
 import app from '../index';
@@ -545,6 +546,60 @@ describe(' (29) signin with valid information as mentor and session available,(r
     chai.request(app)
       .patch('/api/v1/2/reject')
       .set('authorization', mentor_token)
+      .end((err, res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(200);
+        expect(res.body.status).to.equal(200);
+        done();
+      });
+  });
+});
+
+
+// session that correspond to mentor or mentee
+
+
+describe(' (30) signin with valid information  to get sessions as mentor or mentee ', () => {
+  const user_info = user[4];
+  const admin_token = jwt.sign({ user_info }, process.env.PASS_KEY, { expiresIn: '1h' });
+  it('should return info', (done) => {
+    chai.request(app)
+      .get('/api/v1/sessions')
+      .set('authorization', admin_token)
+      .end((err, res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(403);
+        expect(res.body.status).to.equal(403);
+        expect(res.body.message).to.equal('forbidden, create account please..');
+        done();
+      });
+  });
+});
+
+describe(' (31) signin with valid information  to get sessions as mentor (200) ', () => {
+  const user_info = user[3];
+  const mentor_token = jwt.sign({ user_info }, process.env.PASS_KEY, { expiresIn: '1h' });
+  it('should return info', (done) => {
+    chai.request(app)
+      .get('/api/v1/sessions')
+      .set('authorization', mentor_token)
+      .end((err, res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(200);
+        expect(res.body.status).to.equal(200);
+        done();
+      });
+  });
+});
+
+
+describe(' (32) signin with valid information  to get sessions as mentee (200) ', () => {
+  const user_info = user[1];
+  const mentee_token = jwt.sign({ user_info }, process.env.PASS_KEY, { expiresIn: '1h' });
+  it('should return info', (done) => {
+    chai.request(app)
+      .get('/api/v1/sessions')
+      .set('authorization', mentee_token)
       .end((err, res) => {
         expect(res.body).to.be.an('object');
         expect(res.status).to.equal(200);


### PR DESCRIPTION
#### What does this PR do?
> Add view sessions functionaty
#### Description ?
> Mentor should be able to view all session done agaist him, and Mentee should
be able to view all session he has create for different mentors
#### How should this be manually tested?
> clone or run our project manually
#### What are the relevant pivotal tracker stories?
> user should be able to view mentorship session request, story with id #168096678
#### Screenshots (if appropriate)
> N/A

[finishes #168096678]